### PR TITLE
Fix HTML attribute values written without encoding on server

### DIFF
--- a/WebSharper.Html.Server/Html.fs
+++ b/WebSharper.Html.Server/Html.fs
@@ -62,7 +62,7 @@ module Html =
                 | Some a -> a.Requires
 
             member this.Write(meta, w) =
-                w.WriteAttribute(this.Name, this.Value)
+                w.WriteAttribute(this.Name, this.Value, true)
 
             member this.Encode(meta, json) =
                 []


### PR DESCRIPTION
HTML attribute values are currently no encoded when HTML markup is rendered on the server side. This makes application vulnerable to script injection attacks and it is also inconsistent with the client-side markup rendering, as well as text nodes rendering.
